### PR TITLE
Support execution from ITCM/DTCM (Don't modify FLASH in MCU).

### DIFF
--- a/Core/Src/system_stm32h7xx.c
+++ b/Core/Src/system_stm32h7xx.c
@@ -263,6 +263,8 @@ void SystemInit (void)
   /* Configure the Vector Table location add offset address for cortex-M7 ------------------*/
 #ifdef VECT_TAB_SRAM
   SCB->VTOR = D1_AXISRAM_BASE  | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal AXI-RAM */
+#elif defined(VECT_TAB_ITCM)
+  SCB->VTOR = CD_ITCMRAM_BASE  | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal ITCM-RAM */
 #else
   SCB->VTOR = FLASH_BANK1_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
 #endif

--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,8 @@ AS_DEFS =
 # C defines
 C_DEFS =  \
 -DUSE_HAL_DRIVER \
--DSTM32H7B0xx
-
+-DSTM32H7B0xx \
+-DVECT_TAB_ITCM
 
 # AS includes
 AS_INCLUDES = 

--- a/STM32H7B0VBTx_FLASH.ld
+++ b/STM32H7B0VBTx_FLASH.ld
@@ -72,13 +72,13 @@ MEMORY
 SECTIONS
 {
   
-  /* The startup code goes first into FLASH */
+  /* The startup code goes first into ITCMRAM */
   .isr_vector :
   {
     . = ALIGN(4);
     KEEP(*(.isr_vector)) /* Startup code */
     . = ALIGN(4);
-  } >DTCMRAM
+  } >ITCMRAM
 
 
   .lcd :
@@ -95,7 +95,7 @@ SECTIONS
     _extflash = .;       /* define a global symbols to point at the external flash */
   } >EXTFLASH
 
-  /* The program code and other data goes into FLASH */
+  /* The program code and other data goes into ITCMRAM */
   .text :
   {
     . = ALIGN(4);
@@ -110,9 +110,9 @@ SECTIONS
 
     . = ALIGN(4);
     _etext = .;        /* define a global symbols at end of code */
-  } >DTCMRAM
+  } >ITCMRAM
 
-  /* Constant data goes into FLASH */
+  /* Constant data goes into DTCMRAM */
   .rodata :
   {
     . = ALIGN(4);
@@ -121,7 +121,7 @@ SECTIONS
     . = ALIGN(4);
   } >DTCMRAM
 
-  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >FLASH
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >DTCMRAM
   .ARM : {
     __exidx_start = .;
     *(.ARM.exidx*)
@@ -156,12 +156,13 @@ SECTIONS
   .data : 
   {
     . = ALIGN(4);
+    /* Note: _sdata and _edata are placed together to disable data initialization from FLASH */
     _sdata = .;        /* create a global symbol at data start */
+    _edata = .;        /* define a global symbol at data end */
     *(.data)           /* .data sections */
     *(.data*)          /* .data* sections */
 
     . = ALIGN(4);
-    _edata = .;        /* define a global symbol at data end */
   } >DTCMRAM
 
   

--- a/flash.sh
+++ b/flash.sh
@@ -63,8 +63,8 @@ openocd -f ${DIR}/adapter_config.cfg \
     -c "mww ${VAR_program_address} ${ADDRESS}" \
     -c "mww ${VAR_program_magic} ${MAGIC}" \
     -c "mww ${VAR_program_erase} ${ERASE}" \
-    -c "reg sp [mrw 0x20000000];" \
-    -c "reg pc [mrw 0x20000004];" \
+    -c "reg sp [mrw 0x00000000];" \
+    -c "reg pc [mrw 0x00000004];" \
     -c "echo \"Starting flash process\";" \
     -c "resume; exit;"
 


### PR DESCRIPTION
Update: This pull request merges the previous proposal with the current state of the main branch and now provides improvements in several minor aspects, with the aim to improve on speed and extensibility.

What is now changed:
- Move all executable code from DTCM to ITCM. This will cause the processor to take advantage of simultaneous access to both tightly coupled memories.
- Relocate the interrupt vector table in the NVIC so it resides in ITCM. This one is quite critical, as any interrupt could crash the system as currently is (user code would run from FLASH, outside of any valid program state).
- Disable .data section initialization (was previously from FLASH), as this is now automatically done by the debugger (previous implementation just copied data over to the same place).

We hope you can find this useful. Have a nice day!

--- Original PR description ---
> Hello! I'm Joksan from Hacker Space San Salvador. Here's a little enhancement so we don't need to re-flash the MCU each time we want to load the external flash.
> 
> Here's a brief on the modifications:
> - Relocate all relevant code and data sections in the linker script.
> - Relocate the vector table to ITCM.
> - Disable .data section initialization from FLASH.
> - Modify the flash.sh script so program is loaded into ITCM/DTCM and the program counter is set to the reset handler.
> 
> We hope you like it! Tell us what you think.