### PR TITLE
Automatically download sources from the STM32CubeH7 SDK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A small tool to flash the SPI-flash using OpenOCD.
 
 ## Usage
 
-- Initialize using STM32CubeMX
+- (Optional) Initialize using STM32CubeMX or dowload all SDK files using `make download_sdk -j`
 - Build the code using `make`
 - Run `flash.sh`, point it to the image you want to flash
 - Wait until your device blinks once a second


### PR DESCRIPTION
The current proposal addresses prerequisite fulfillment during compilation, as mentioned in issues #2 and #3. The proposed solution consists in having Make download all sources under demand without further user intervention beyond invoking Make with the intent of program compilation.

I expect this solution  to be compatible with the previous procedure of using STM32CubeMX for project initialization, although I haven't found the time to test this (I don't usually use IDEs for development). I'll be glad to address any issue that may arise in this regard (assuming the old initialization procedure is expected to be preserved).

Also, the user should be able to invoke make with a new target called `download_sdk`, which performs all downloads ahead of time. If this is combined with parallel execution, very fast download times can be achieved, like this:
`$ make download_sdk -j`

There's also the option to simply call Make without arguments, although this can be pretty slow, as several files will be downloaded sequentally. Once again, if parrallel execution is enabled, the whole program can be downloaded and compiled very fast, like this:
`$ make -j`

Finally, invoking the `clean` target doesn't delete downloaded files. A new `distclean` target has been added for this specific purpose instead.

Modification details:
- Added configuration options for SDK location and version.
- Separated source tracking variables into application C sources, SDK C sources, SDK ASM sources and
  and SDK headers (the latter were added so they can be downloaded individually).
- Added automated prerequisite generation for SDK object file rules. This compensates for the fact
  that chains of implicit rules cannot work anymore as they did, as file location can't be
  determined through vpath anymore (downloaded files don't exist until after rules are procesed).