### PR TITLE
support for raspberry pi

### DIFF
--- a/interface_rpi.cfg
+++ b/interface_rpi.cfg
@@ -1,0 +1,6 @@
+source [find interface/sysfsgpio-raspberrypi.cfg]
+sysfsgpio_swd_nums 25 24
+sysfsgpio_srst_num 23
+transport select swd
+source [find target/stm32h7x.cfg]
+reset_config none


### PR DESCRIPTION
tried on rpi with `export ADAPTER="rpi"` and works fine